### PR TITLE
Disable navigation from step1 and step2 on click of steps

### DIFF
--- a/webroot/common/ui/scss/contrail.custom.scss
+++ b/webroot/common/ui/scss/contrail.custom.scss
@@ -2688,6 +2688,7 @@ $active-color: #3182bd;
     background: -o-linear-gradient(#f7fdff, white);
     background: -moz-linear-gradient(#f7fdff, white);
     background: linear-gradient(#f7fdff, white);
+    pointer-events: none;
     a {
       background: transparent;
       &:hover {
@@ -2730,6 +2731,9 @@ $active-color: #3182bd;
       width: 50%;
       margin-left: -40px;
       padding: 10px;
+    }
+    &.wizard > .content{
+      min-height:380px !important;
     }
     &.wizard > .steps ul li {
       .title {


### PR DESCRIPTION
Assign height for grids in popup..such that footer is visible always

Change-Id: I7fc9ead1e6c86ba9fde5127ea4ff5958a787923a